### PR TITLE
Fix crash when payload contains more than just .app folder; compress output IPA

### DIFF
--- a/IPAEdit.xcodeproj/project.pbxproj
+++ b/IPAEdit.xcodeproj/project.pbxproj
@@ -446,7 +446,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MARKETING_VERSION = 5.0;
+				MARKETING_VERSION = 5.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Ethan-Goodhart.IPAEdit";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -469,7 +469,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MARKETING_VERSION = 5.0;
+				MARKETING_VERSION = 5.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Ethan-Goodhart.IPAEdit";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/IPAEdit/Base.lproj/Main.storyboard
+++ b/IPAEdit/Base.lproj/Main.storyboard
@@ -685,7 +685,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="Upload IPA" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" title="Choose IPA" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <rect key="contentRect" x="0.0" y="270" width="480" height="270"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>

--- a/IPAEdit/EditController.swift
+++ b/IPAEdit/EditController.swift
@@ -185,7 +185,7 @@ class EditController: NSViewController, NSTextFieldDelegate {
         
         DispatchQueue.global(qos: .userInteractive).async {
             do {
-                var exportedFileName = self.ipaFileName + " [IPAEdit]"
+                var exportedFileName = self.ipaFileName + "_IPAEdit"
                 var oc = ""
                 
                 while FileManager.default.fileExists(atPath: self.appPath.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent(exportedFileName + oc + ".ipa").path) {
@@ -200,7 +200,7 @@ class EditController: NSViewController, NSTextFieldDelegate {
                 exportedFileName = exportedFileName + oc
                 
                 if !FileManager.default.fileExists(atPath: self.appPath.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent(exportedFileName + ".zip").path) {
-                    try FileManager.default.zipItem(at: self.appPath.deletingLastPathComponent(), to: self.appPath.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent(exportedFileName + ".zip"), progress: p)
+                    try FileManager.default.zipItem(at: self.appPath.deletingLastPathComponent(), to: self.appPath.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent(exportedFileName + ".zip"), compressionMethod: .deflate, progress: p)
                 }
             
                 try FileManager.default.moveItem(at: self.appPath.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent(exportedFileName + ".zip"), to: self.appPath.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent(exportedFileName + ".ipa"))

--- a/IPAEdit/ViewController.swift
+++ b/IPAEdit/ViewController.swift
@@ -40,7 +40,12 @@ class ViewController: NSViewController {
         DispatchQueue.main.async {
             do {
                 let payloadContents = try FileManager.default.contentsOfDirectory(at: URL(fileURLWithPath: self.ipaCopy + "/Payload"), includingPropertiesForKeys: nil, options: [.skipsSubdirectoryDescendants, .skipsHiddenFiles])
-                self.appPath = payloadContents.first!
+                for item in payloadContents {
+                    if item.absoluteString.contains(".app") {
+                        self.appPath = item
+                        break
+                    }
+                }
                 self.performSegue(withIdentifier: "editsegue", sender: self)
             } catch {
                 print("Error extracting payload from IPA \(error)")


### PR DESCRIPTION
There was a crash when I tried to modify the icon for uYouEnhanced, version 19.01.1_3.0.1 (available [here][IPA_LINK]). This happened because there was another file in the `Payload` folder called `decrypt.day`, and that was used to set the `appPath` in IPAEdit. I fixed this crash by looping through the contents of `Payload` and only accepting the file that contains `".app"` instead of just taking the first file.

[IPA_LINK]: https://github.com/arichornlover/uYouEnhanced/releases/download/v19.01.1-3.0.1/uYouEnhanced_19.01.1_3.0.1.ipa